### PR TITLE
Dev/kafka connect

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    compile (
+            "ch.qos.logback:logback-classic:1.2.3",
+            "org.codehaus.groovy:groovy-all:2.4.9"
+    )
+}

--- a/common/src/main/java/platform/common/Constants.java
+++ b/common/src/main/java/platform/common/Constants.java
@@ -2,6 +2,8 @@ package platform.common;
 
 public class Constants {
 
-  public static final String PLATFORM_PACKAGE = "platform";
+  public static final String PACKAGE_PLATFORM = "platform";
 
+  public static final String SERVICE_REDIS = "redis";
+  public static final String SERVICE_KAFKA = "kafka";
 }

--- a/common/src/main/java/platform/common/ServiceLocatorHelper.java
+++ b/common/src/main/java/platform/common/ServiceLocatorHelper.java
@@ -6,7 +6,6 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.jvnet.hk2.annotations.Service;
 
-import javax.inject.Singleton;
 import java.io.IOException;
 
 public class ServiceLocatorHelper {
@@ -31,7 +30,7 @@ public class ServiceLocatorHelper {
 
       ImmutableSet<ClassPath.ClassInfo> allClasses =
           ClassPath.from(ClassLoader.getSystemClassLoader())
-              .getTopLevelClassesRecursive(Constants.PLATFORM_PACKAGE);
+              .getTopLevelClassesRecursive(Constants.PACKAGE_PLATFORM);
       Class<?>[] serviceClasses = allClasses.stream()
           .map(ClassPath.ClassInfo::load)
           .filter(classObject -> classObject.isAnnotationPresent(Service.class))

--- a/common/src/main/java/platform/common/io/log/Log.java
+++ b/common/src/main/java/platform/common/io/log/Log.java
@@ -1,0 +1,9 @@
+package platform.common.io.log;
+
+
+import org.jvnet.hk2.annotations.Contract;
+
+@Contract
+public interface Log {
+  public void info(String message);
+}

--- a/common/src/main/java/platform/common/io/log/impl/FileLog.java
+++ b/common/src/main/java/platform/common/io/log/impl/FileLog.java
@@ -1,0 +1,21 @@
+package platform.common.io.log.impl;
+
+import org.jvnet.hk2.annotations.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import platform.common.io.log.Log;
+
+@Service
+public class FileLog implements Log {
+  private final Logger logger;
+
+  public FileLog() {
+    logger = LoggerFactory.getLogger(FileLog.class);
+    System.out.println("logger.isInfoEnabled() = " + logger.isInfoEnabled());
+  }
+
+  @Override
+  public void info(String message) {
+    logger.info(message);
+  }
+}

--- a/common/src/main/resources/logback.groovy
+++ b/common/src/main/resources/logback.groovy
@@ -1,0 +1,29 @@
+import ch.qos.logback.classic.AsyncAppender
+
+def logPath="/log"
+def logArchive="${logPath}/archive"
+
+appender("Console-Appender", ConsoleAppender) {
+    encoder(PatternLayoutEncoder) {
+        pattern = "%msg%n"
+    }
+}
+
+appender("RollingFile-Appender", RollingFileAppender) {
+    file = "${logPath}/logfile.log"
+    rollingPolicy(TimeBasedRollingPolicy) {
+        fileNamePattern = "${logArchive}/rollingfile.log%d{yyyy-MM-dd}.log"
+        maxHistory = 30
+        totalSizeCap = "1GB"
+    }
+    encoder(PatternLayoutEncoder) {
+        pattern = "%msg%n"
+        outputPatternAsHeader = true
+    }
+}
+
+appender("Async-Appender",AsyncAppender){
+    appenderRef("RollingFile-Appender")
+}
+
+root(INFO,["Console-Appender", "Async-Appender"])

--- a/common/src/main/resources/logback.groovy
+++ b/common/src/main/resources/logback.groovy
@@ -1,20 +1,22 @@
 import ch.qos.logback.classic.AsyncAppender
+import ch.qos.logback.core.util.FileSize
 
 def logPath="/log"
 def logArchive="${logPath}/archive"
 
 appender("Console-Appender", ConsoleAppender) {
     encoder(PatternLayoutEncoder) {
-        pattern = "%msg%n"
+        pattern = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
     }
 }
 
 appender("RollingFile-Appender", RollingFileAppender) {
-    file = "${logPath}/logfile.log"
+    file = "${logPath}/platform.log"
     rollingPolicy(TimeBasedRollingPolicy) {
-        fileNamePattern = "${logArchive}/rollingfile.log%d{yyyy-MM-dd}.log"
+        fileNamePattern = "${logArchive}/platform.log%d{yyyy-MM-dd}.log"
         maxHistory = 30
-        totalSizeCap = "1GB"
+        totalSizeCap = FileSize.valueOf("1 GB")
+
     }
     encoder(PatternLayoutEncoder) {
         pattern = "%msg%n"

--- a/common/src/main/resources/logback.groovy
+++ b/common/src/main/resources/logback.groovy
@@ -4,22 +4,24 @@ import ch.qos.logback.core.util.FileSize
 def logPath="/log"
 def logArchive="${logPath}/archive"
 
+def logPattern = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+
 appender("Console-Appender", ConsoleAppender) {
     encoder(PatternLayoutEncoder) {
-        pattern = "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+        pattern = "${logPattern}"
     }
 }
 
 appender("RollingFile-Appender", RollingFileAppender) {
     file = "${logPath}/platform.log"
     rollingPolicy(TimeBasedRollingPolicy) {
-        fileNamePattern = "${logArchive}/platform.log%d{yyyy-MM-dd}.log"
+        fileNamePattern = "${logArchive}/platform-%d{yyyy-MM-dd}.log"
         maxHistory = 30
         totalSizeCap = FileSize.valueOf("1 GB")
 
     }
     encoder(PatternLayoutEncoder) {
-        pattern = "%msg%n"
+        pattern = "${logPattern}"
         outputPatternAsHeader = true
     }
 }

--- a/common/src/test/groovy/platform/common/io/log/impl/FileLogTest.groovy
+++ b/common/src/test/groovy/platform/common/io/log/impl/FileLogTest.groovy
@@ -4,7 +4,7 @@ import org.junit.Ignore
 import platform.common.io.log.Log
 import platform.common.test.BaseSpecification
 
-@Ignore("Enable after finding solution to ensure presence of log directory")
+@Ignore("Enable after finding solution to ensure presence of log directory. may be using logback-test config file")
 class FileLogTest extends BaseSpecification {
     def "Info"() {
         expect:

--- a/common/src/test/groovy/platform/common/io/log/impl/FileLogTest.groovy
+++ b/common/src/test/groovy/platform/common/io/log/impl/FileLogTest.groovy
@@ -1,0 +1,14 @@
+package platform.common.io.log.impl
+
+import org.junit.Ignore
+import platform.common.io.log.Log
+import platform.common.test.BaseSpecification
+
+@Ignore("Enable after finding solution to ensure presence of log directory")
+class FileLogTest extends BaseSpecification {
+    def "Info"() {
+        expect:
+        Log log = serviceLocator.getService(Log.class);
+        log.info("Test log message");
+    }
+}

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -8,6 +8,7 @@ apply from: "$rootProject.projectDir/gradle/script/docker.gradle"
 dependencies {
     implementation(
             project(':web'),
+            project(':kafkaAdmin'),
             project(':data')
     )
 

--- a/config/src/integrationTest/groovy/platform/config/resource/ConfigWebTest.groovy
+++ b/config/src/integrationTest/groovy/platform/config/resource/ConfigWebTest.groovy
@@ -19,7 +19,7 @@ class ConfigWebTest extends Specification{
     }
     def "test Config Service"() {
         setup:
-        String configId = "kafkaUrl";
+        String configId = ConfigConstants.PROPERTY_KAFKA_URL;
         String configValue=  "kafkaHost:9092"
         ClientBuilder clientBuilder = ClientBuilder.newBuilder();
         WebTarget target = clientBuilder.build().target(baseUrl).path(ConfigConstants.RESOURCE_PROPERTY_PATH)

--- a/config/src/main/java/platform/config/ConfigConstants.java
+++ b/config/src/main/java/platform/config/ConfigConstants.java
@@ -5,4 +5,8 @@ public class ConfigConstants {
   public static final String RESOURCE_PROPERTY_PATH = "/config/property";
   public static final String RESOURCE_PROPERTY_PARAM_PATH = "{propertyId}";
   public static final String RESOURCE_PROPERTY_PARAM_NAME = "propertyId";
+
+  public static final String PROPERTY_KAFKA_URL = "kafkaUrl";
+
+  public static final String TOPIC_CONFIG_EVENTS = "configEvents";
 }

--- a/config/src/main/java/platform/config/processor/ConfigProcessor.java
+++ b/config/src/main/java/platform/config/processor/ConfigProcessor.java
@@ -1,0 +1,12 @@
+package platform.config.processor;
+
+import org.jvnet.hk2.annotations.Contract;
+import org.jvnet.hk2.annotations.Service;
+
+import static platform.config.ConfigConstants.PROPERTY_KAFKA_URL;
+
+@Contract
+public interface ConfigProcessor {
+
+  public void process(String propertyId, String propertyValue);
+}

--- a/config/src/main/java/platform/config/processor/impl/KafkaConfigProcessor.java
+++ b/config/src/main/java/platform/config/processor/impl/KafkaConfigProcessor.java
@@ -2,6 +2,7 @@ package platform.config.processor.impl;
 
 import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.annotations.Service;
+import platform.common.io.log.Log;
 import platform.config.processor.ConfigProcessor;
 import platform.config.resource.Config;
 import platform.kafka.admin.TopicManager;
@@ -15,11 +16,13 @@ import static platform.config.ConfigConstants.TOPIC_CONFIG_EVENTS;
 public class KafkaConfigProcessor implements ConfigProcessor {
   private final TopicManager topicManager;
   private final ServiceLocator serviceLocator;
+  private final Log log;
 
   @Inject
   public KafkaConfigProcessor(ServiceLocator serviceLocator, TopicManager topicManager) {
     this.serviceLocator = serviceLocator;
     this.topicManager = topicManager;
+    log = serviceLocator.getService(Log.class);
   }
 
   @Override
@@ -28,9 +31,9 @@ public class KafkaConfigProcessor implements ConfigProcessor {
       String kafkaUrl = serviceLocator.getService(Config.class).getConfig(PROPERTY_KAFKA_URL);
       topicManager.setKafkaBootstrapServer(kafkaUrl);
       //TODO Make createTopic parameters dynamic
-      System.out.println("List of topics: " + topicManager.getTopics());
       topicManager.createTopic(TOPIC_CONFIG_EVENTS, 1, (short) 1);
-      System.out.println("Created topic: " + TOPIC_CONFIG_EVENTS);
+      log.info("Created topic: " + TOPIC_CONFIG_EVENTS);
+      log.info("List of topics: " + topicManager.getTopics());
     }).start();
   }
 }

--- a/config/src/main/java/platform/config/processor/impl/KafkaConfigProcessor.java
+++ b/config/src/main/java/platform/config/processor/impl/KafkaConfigProcessor.java
@@ -31,8 +31,10 @@ public class KafkaConfigProcessor implements ConfigProcessor {
       String kafkaUrl = serviceLocator.getService(Config.class).getConfig(PROPERTY_KAFKA_URL);
       topicManager.setKafkaBootstrapServer(kafkaUrl);
       //TODO Make createTopic parameters dynamic
-      topicManager.createTopic(TOPIC_CONFIG_EVENTS, 1, (short) 1);
-      log.info("Created topic: " + TOPIC_CONFIG_EVENTS);
+      if (!topicManager.getTopics().contains(TOPIC_CONFIG_EVENTS)) {
+        topicManager.createTopic(TOPIC_CONFIG_EVENTS, 1, (short) 1);
+        log.info("Created topic: " + TOPIC_CONFIG_EVENTS);
+      }
       log.info("List of topics: " + topicManager.getTopics());
     }).start();
   }

--- a/config/src/main/java/platform/config/processor/impl/KafkaConfigProcessor.java
+++ b/config/src/main/java/platform/config/processor/impl/KafkaConfigProcessor.java
@@ -1,0 +1,36 @@
+package platform.config.processor.impl;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.jvnet.hk2.annotations.Service;
+import platform.config.processor.ConfigProcessor;
+import platform.config.resource.Config;
+import platform.kafka.admin.TopicManager;
+
+import javax.inject.Inject;
+
+import static platform.config.ConfigConstants.PROPERTY_KAFKA_URL;
+import static platform.config.ConfigConstants.TOPIC_CONFIG_EVENTS;
+
+@Service(name = PROPERTY_KAFKA_URL)
+public class KafkaConfigProcessor implements ConfigProcessor {
+  private final TopicManager topicManager;
+  private final ServiceLocator serviceLocator;
+
+  @Inject
+  public KafkaConfigProcessor(ServiceLocator serviceLocator, TopicManager topicManager) {
+    this.serviceLocator = serviceLocator;
+    this.topicManager = topicManager;
+  }
+
+  @Override
+  public void process(String propertyId, String propertyValue) {
+    new Thread(() -> {
+      String kafkaUrl = serviceLocator.getService(Config.class).getConfig(PROPERTY_KAFKA_URL);
+      topicManager.setKafkaBootstrapServer(kafkaUrl);
+      //TODO Make createTopic parameters dynamic
+      System.out.println("List of topics: " + topicManager.getTopics());
+      topicManager.createTopic(TOPIC_CONFIG_EVENTS, 1, (short) 1);
+      System.out.println("Created topic: " + TOPIC_CONFIG_EVENTS);
+    }).start();
+  }
+}

--- a/config/src/main/java/platform/config/resource/Config.java
+++ b/config/src/main/java/platform/config/resource/Config.java
@@ -1,7 +1,10 @@
 package platform.config.resource;
 
+import org.glassfish.hk2.api.ServiceLocator;
 import org.jvnet.hk2.annotations.Service;
+import platform.common.io.log.Log;
 import platform.config.ConfigConstants;
+import platform.config.processor.ConfigProcessor;
 import platform.data.provider.KeyValueProvider;
 
 import javax.inject.Inject;
@@ -15,10 +18,14 @@ import javax.ws.rs.core.Response;
 @Path(ConfigConstants.RESOURCE_PROPERTY_PATH)
 public class Config {
   private final KeyValueProvider keyValueProvider;
+  private final ServiceLocator serviceLocator;
+  private final Log log;
 
   @Inject
-  public Config(KeyValueProvider keyValueProvider) {
+  public Config(ServiceLocator serviceLocator, KeyValueProvider keyValueProvider, Log log) {
+    this.serviceLocator = serviceLocator;
     this.keyValueProvider = keyValueProvider;
+    this.log = log;
   }
 
   @Path(ConfigConstants.RESOURCE_PROPERTY_PARAM_PATH)
@@ -32,7 +39,14 @@ public class Config {
   @PUT
   public Response setConfig(@PathParam(ConfigConstants.RESOURCE_PROPERTY_PARAM_NAME)
                                   String propertyId, String propertyValue) {
+    System.out.println("Inside setConfig");
+    log.info("Inside setConfig");
     keyValueProvider.setString(propertyId, propertyValue);
+    ConfigProcessor configProcessor = serviceLocator.getService(ConfigProcessor.class, propertyId);
+    log.info("configProcessor: " + configProcessor);
+    if (configProcessor != null) {
+      configProcessor.process(propertyId, propertyValue);
+    }
     return Response.ok().build();
   }
 }

--- a/config/src/main/java/platform/config/resource/Config.java
+++ b/config/src/main/java/platform/config/resource/Config.java
@@ -39,8 +39,6 @@ public class Config {
   @PUT
   public Response setConfig(@PathParam(ConfigConstants.RESOURCE_PROPERTY_PARAM_NAME)
                                   String propertyId, String propertyValue) {
-    System.out.println("Inside setConfig");
-    log.info("Inside setConfig");
     keyValueProvider.setString(propertyId, propertyValue);
     ConfigProcessor configProcessor = serviceLocator.getService(ConfigProcessor.class, propertyId);
     log.info("configProcessor: " + configProcessor);

--- a/config/src/main/resources/docker-compose.yml
+++ b/config/src/main/resources/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       servicePort: ${servicePort}
     ports:
       - "${servicePort}:${servicePort}"
+    volumes:
+      - /scratch/dockerVolumes1/log/${repository}:/log
   redis:
     image: redis
     ports:

--- a/config/src/test/groovy/ConfigTest.groovy
+++ b/config/src/test/groovy/ConfigTest.groovy
@@ -1,15 +1,21 @@
+import org.glassfish.hk2.api.ServiceLocator
+import platform.common.io.log.Log
 import platform.common.test.BaseSpecification
+import platform.config.ConfigConstants
+import platform.config.processor.ConfigProcessor
 import platform.config.resource.Config
 import platform.data.provider.KeyValueProvider
 
 class ConfigTest extends BaseSpecification{
     def "Get Config"() {
         setup:
-        String configId = "kafkaUrl";
+        String configId = ConfigConstants.PROPERTY_KAFKA_URL;
         String mockConfigValue=  "kafkaHost:9092"
         KeyValueProvider mockKeyValueProvider = Mock()
+        ServiceLocator mockServiceLocator = Mock()
         mockKeyValueProvider.getString(configId) >> mockConfigValue
-        Config config = new Config(mockKeyValueProvider);
+        Log mockLog = Mock()
+        Config config = new Config(mockServiceLocator, mockKeyValueProvider, mockLog);
 
         when:
         String configValue = config.getConfig(configId);
@@ -20,15 +26,20 @@ class ConfigTest extends BaseSpecification{
 
     def "Set Config"() {
         setup:
-        String configId = "kafkaUrl";
+        String configId = ConfigConstants.PROPERTY_KAFKA_URL;
         String configValue=  "kafkaHost:9092"
         KeyValueProvider mockKeyValueProvider = Mock()
-        Config config = new Config(mockKeyValueProvider);
+        ServiceLocator mockServiceLocator = Mock()
+        ConfigProcessor mockConfigProcessor = Mock()
+        mockServiceLocator.getService(ConfigProcessor.class, ConfigConstants.PROPERTY_KAFKA_URL) >> mockConfigProcessor
+        Log mockLog = Mock()
+        Config config = new Config(mockServiceLocator, mockKeyValueProvider, mockLog);
 
         when:
         config.setConfig(configId, configValue);
 
         then:
         1 * mockKeyValueProvider.setString(configId, configValue)
+        1 * mockConfigProcessor.process(configId, configValue)
     }
 }

--- a/data/src/main/java/platform/data/provider/impl/RedisClientFactory.java
+++ b/data/src/main/java/platform/data/provider/impl/RedisClientFactory.java
@@ -4,6 +4,7 @@ import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import org.glassfish.hk2.api.Factory;
 import org.jvnet.hk2.annotations.Service;
+import platform.common.Constants;
 
 @Service
 public class RedisClientFactory implements Factory<RedisClient> {
@@ -16,7 +17,7 @@ public class RedisClientFactory implements Factory<RedisClient> {
     RedisClient redisClient =
         RedisClient.create(
             RedisURI.Builder
-                .redis("redis", 6379)
+                .redis(Constants.SERVICE_REDIS, 6379)
                 .withDatabase(0).build());
 //                .redis("redis-17291.c1.us-west-2-2.ec2.cloud.redislabs.com", 17291)
 //          .withDatabase(0).withPassword("jkyMnnc0ZxKMXKCzf2ieilsTrqbwIkIZ").build());

--- a/data/src/main/java/platform/data/provider/impl/RedisKeyValueProvider.java
+++ b/data/src/main/java/platform/data/provider/impl/RedisKeyValueProvider.java
@@ -11,12 +11,10 @@ import javax.inject.Inject;
 
 @Service(name = DataRepositoryType.REDIS)
 public class RedisKeyValueProvider implements KeyValueProvider {
-  RedisClient redisClient;
   StatefulRedisConnection<String, String> statefulRedisConnection;
 
   @Inject
   public RedisKeyValueProvider(RedisClient redisClient) {
-    this.redisClient = redisClient;
     statefulRedisConnection = redisClient.connect();
   }
 

--- a/event/src/main/java/platform/event/processor/EventProcessor.java
+++ b/event/src/main/java/platform/event/processor/EventProcessor.java
@@ -4,5 +4,5 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 @FunctionalInterface
 public interface EventProcessor {
-    public void process(ConsumerRecord<String, String> consumerRecord);
+  public void process(ConsumerRecord<String, String> consumerRecord);
 }

--- a/event/src/main/java/platform/event/producer/impl/EventProducerImpl.java
+++ b/event/src/main/java/platform/event/producer/impl/EventProducerImpl.java
@@ -12,7 +12,7 @@ public class EventProducerImpl implements EventProducer {
 
   public static void main(String[] args) {
     EventProducer eventProducer = new EventProducerImpl();
-    eventProducer.publish("second", "event1");
+    eventProducer.publish("configEvents", "{\"key1\":\"value1\"}");
   }
 
   @Override

--- a/gradle/script/subCommon.gradle
+++ b/gradle/script/subCommon.gradle
@@ -7,7 +7,7 @@ dependencies {
             ['com.google.guava:guava:23.0']
     )
     testImplementation (
-            ['org.spockframework:spock-core:1.1-groovy-2.4-rc-2'],
+            ['org.spockframework:spock-core:1.1-groovy-2.4'],
             ['org.hamcrest:hamcrest-library:1.3'],
             ['cglib:cglib:2.2'],
             ['org.objenesis:objenesis:2.2'],

--- a/kafka/src/main/resources/rhel/docker-compose.yml
+++ b/kafka/src/main/resources/rhel/docker-compose.yml
@@ -14,5 +14,6 @@ services:
       KAFKA_BROKER_ID: 2
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - /scratch/dockerVolumes1/kafka:/kafka
     entrypoint: [start-kafka.sh]
 

--- a/kafkaAdmin/src/main/java/platform/kafka/admin/TopicManager.java
+++ b/kafkaAdmin/src/main/java/platform/kafka/admin/TopicManager.java
@@ -1,8 +1,11 @@
 package platform.kafka.admin;
 
 
+import org.jvnet.hk2.annotations.Contract;
+
 import java.util.Set;
 
+@Contract
 public interface TopicManager {
 
   Boolean createTopic(String topic, int partitions, short replication);

--- a/kafkaAdmin/src/main/java/platform/kafka/admin/impl/KafkaAdminInitializer.java
+++ b/kafkaAdmin/src/main/java/platform/kafka/admin/impl/KafkaAdminInitializer.java
@@ -1,0 +1,25 @@
+package platform.kafka.admin.impl;
+
+import org.glassfish.hk2.api.PostConstruct;
+import org.glassfish.hk2.runlevel.RunLevel;
+import org.jvnet.hk2.annotations.Service;
+import platform.kafka.admin.TopicManager;
+
+import javax.inject.Inject;
+
+@Service
+@RunLevel(5)
+public class KafkaAdminInitializer implements PostConstruct {
+
+  private final TopicManager topicManager;
+
+  @Inject
+  public KafkaAdminInitializer(TopicManager topicManager) {
+    this.topicManager = topicManager;
+  }
+
+  @Override
+  public void postConstruct() {
+    System.out.println("Inside KafkaAdminInitializer: topicManager = " + topicManager);
+  }
+}

--- a/kafkaAdmin/src/main/java/platform/kafka/admin/impl/KafkaAdminInitializer.java
+++ b/kafkaAdmin/src/main/java/platform/kafka/admin/impl/KafkaAdminInitializer.java
@@ -1,8 +1,10 @@
 package platform.kafka.admin.impl;
 
 import org.glassfish.hk2.api.PostConstruct;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.runlevel.RunLevel;
 import org.jvnet.hk2.annotations.Service;
+import platform.common.io.log.Log;
 import platform.kafka.admin.TopicManager;
 
 import javax.inject.Inject;
@@ -12,14 +14,16 @@ import javax.inject.Inject;
 public class KafkaAdminInitializer implements PostConstruct {
 
   private final TopicManager topicManager;
+  private final Log log;
 
   @Inject
-  public KafkaAdminInitializer(TopicManager topicManager) {
+  public KafkaAdminInitializer(ServiceLocator serviceLocator, TopicManager topicManager) {
     this.topicManager = topicManager;
+    this.log = serviceLocator.getService(Log.class);
   }
 
   @Override
   public void postConstruct() {
-    System.out.println("Inside KafkaAdminInitializer: topicManager = " + topicManager);
+    log.info("Inside KafkaAdminInitializer: topicManager = " + topicManager);
   }
 }

--- a/kafkaAdmin/src/main/java/platform/kafka/admin/impl/TopicManagerImpl.java
+++ b/kafkaAdmin/src/main/java/platform/kafka/admin/impl/TopicManagerImpl.java
@@ -1,6 +1,8 @@
 package platform.kafka.admin.impl;
 
 
+import org.glassfish.hk2.api.PerLookup;
+import org.jvnet.hk2.annotations.Service;
 import platform.kafka.admin.TopicManager;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
@@ -17,6 +19,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+@Service
+@PerLookup
 class TopicManagerImpl implements TopicManager {
 
   volatile AdminClient adminClient;
@@ -24,9 +28,10 @@ class TopicManagerImpl implements TopicManager {
 
   public static void main(String[] args) {
     TopicManagerImpl topicManager = new TopicManagerImpl();
+    topicManager.setKafkaBootstrapServer("http://slc12nog:9092");
     System.out.println("Getting list of topics...");
     System.out.println("List of topics: " + topicManager.getTopics());
-//    topicManager.createTopic("second",1 , (short)1);
+//    topicManager.createTopic("testTopic1",1 , (short)1);
 //    topicManager.deleteTopic("second");
 //    System.out.println("List of topics: " + topicManager.getTopics());
   }

--- a/web/src/main/java/platform/web/service/Server.java
+++ b/web/src/main/java/platform/web/service/Server.java
@@ -14,7 +14,6 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Optional;
 
 
 public class Server {
@@ -37,7 +36,7 @@ public class Server {
    */
   public HttpServer startServer() {
     // create a resource config that scans for JAX-RS resources and providers
-    final ResourceConfig rc = new ResourceConfig().packages(Constants.PLATFORM_PACKAGE);
+    final ResourceConfig rc = new ResourceConfig().packages(Constants.PACKAGE_PLATFORM);
     rc.register(JacksonJaxbJsonProvider.class, MessageBodyReader.class, MessageBodyWriter.class);
 
     // create and start a new instance of grizzly http server


### PR DESCRIPTION
Summary of changes:
1. Added logging support using slf4j. 
- Currently the logback library is being used as the logging implementation, but slf4j can be configured to use other logging implementations in future. 
- Currently there are some direct calls to log service from config service to test it out, but ultimate idea is to generate appropriate event for every action and those events should be subscribed by the logging service and logged appropriately.
2. Automatically create configEvents topic in Kafka if KafkaUrl property is set in the config service.
